### PR TITLE
Add autoload-dev for behat test path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,5 +115,12 @@
     "drush/drush": "^10.3",
     "drupal/page_load_progress": "^2.0",
     "drupal/memcache": "^2.3"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Drupal\\Tests\\cloud\\Behat\\": "docroot/modules/contrib/cloud/tests/src/Behat",
+      "Drupal\\Tests\\aws_cloud\\Behat\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/aws_cloud/tests/src/Behat",
+      "Drupal\\Tests\\k8s\\Behat\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/k8s/tests/src/Behat"
+    }
   }
 }


### PR DESCRIPTION
Another option is to add '`autoload`' (instead of '`autoload-dev`') in `composer.json` at the `cloud` module.
In that case, the path can be set from $vendorDir. 