### PR TITLE
Add Façade module to installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,7 @@
     "drupal/cloud_orchestrator": "dev-5.x",
     "drupal/copyright_footer": "^2.0",
     "drupal/ctools": "^3.11",
+    "drupal/facade": "1.0.x-dev",
     "drupal/ldap": "^4.3",
     "drupal/login_destination": "^2.0@beta",
     "drupal/memcache": "^2.5",


### PR DESCRIPTION
Adding facade module to distribution.  This is to prep for supporting remote Facade operations.  The normal distributions will not enable this module.  

The Facade related CFn templates will enable this module.  I plan on having a `facade\modules\facade_worker` module that will be enabled.  That module will take of things such as adding the initial set of OpenStack cloud service providers during installation. 

In the future, it will also take care of enabling the `REST` endpoints so we can add additional things to Cloud Orchestrator.