### PR TITLE
Switching to 6.x branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The recommended way to install Cloud Orchestrator is using Composer.
 composer create-project docomoinnovations/cloud_orchestrator cloud_orchestrator
 ```
 
-To use 5.x use the following command.
+To use 6.x use the following command.
 
 ```
 composer create-project docomoinnovations/cloud_orchestrator:5.x-dev cloud_orchestrator

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
       "type": "package",
       "package": {
         "name": "drupal/cloud_orchestrator",
-        "version": "dev-5.x",
+        "version": "dev-6.x",
         "type": "drupal-profile",
         "dist": {
-          "url": "https://ftp.drupal.org/files/projects/cloud_orchestrator-5.x-dev.zip",
+          "url": "https://ftp.drupal.org/files/projects/cloud_orchestrator-6.x-dev.zip",
           "type": "zip"
         }
       }
@@ -96,8 +96,8 @@
     "drupal/core-project-message": "^9.5.x-dev",
     "drupal/core-recommended": "^9.5.x-dev",
     "drupal/admin_toolbar": "^3.2",
-    "drupal/cloud": "5.x-dev",
-    "drupal/cloud_orchestrator": "dev-5.x",
+    "drupal/cloud": "6.x-dev",
+    "drupal/cloud_orchestrator": "dev-6.x",
     "drupal/copyright_footer": "^2.0",
     "drupal/ctools": "^3.11",
     "drupal/facade": "1.0.x-dev",


### PR DESCRIPTION
Setting up the 6.x composer.json to point to 6.x for Cloud and Cloud Orchestrator modules