### PR TITLE
removing page_load_progress until there is a version that supports 10.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ docroot/sites/*/private
 
 # Ignore SimpleTest multi-site environment.
 docroot/sites/simpletest
+/.editorconfig
+/.gitattributes

--- a/composer.json
+++ b/composer.json
@@ -55,12 +55,6 @@
         "web-root": "docroot/"
       }
     },
-    "patches": {
-      "drupal/page_load_progress": {
-        "Fixes path_alias.manager service call": "https://www.drupal.org/files/issues/2020-07-02/page_load_progress.1.x-dev.rector-3148328-4.patch",
-        "Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-08-22/page_load_progress.2.0.0.rector.patch"
-      }
-    },
     "installer-paths": {
       "docroot/core": [
         "type:drupal-core"
@@ -106,7 +100,6 @@
     "drupal/login_destination": "^2.0@beta",
     "drupal/memcache": "^2",
     "drupal/module_filter": "^4",
-    "drupal/page_load_progress": "^2",
     "drupal/queue_ui": "^3",
     "drush/drush": "^11"
   },


### PR DESCRIPTION
@naoi I've removed page_load_progress from the composer.json file.  It is causing issues when trying to build a version of Cloud Orchestrator that uses Drupal 10.x