### PR TITLE
Update composer.json to support Drupal 10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,8 @@
     },
     "patches": {
       "drupal/page_load_progress": {
-        "Fixes path_alias.manager service call": "https://www.drupal.org/files/issues/2020-07-02/page_load_progress.1.x-dev.rector-3148328-4.patch",
-        "Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-08-22/page_load_progress.2.0.0.rector.patch"
-        }
+        "Fixes path_alias.manager service call": "https://www.drupal.org/files/issues/2020-07-02/page_load_progress.1.x-dev.rector-3148328-4.patch"
+      }
     },
     "installer-paths": {
       "docroot/core": [
@@ -106,7 +105,6 @@
     "drupal/login_destination": "^2.0@beta",
     "drupal/memcache": "^2",
     "drupal/module_filter": "^4",
-    "drupal/page_load_progress": "^2",
     "drupal/queue_ui": "^3",
     "drush/drush": "^11"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "docomoinnovations/cloud_orchestrator",
-  "description": "Cloud orchestrator distribution by Docomo Innovations",
+  "description": "Cloud orchestrator distribution by DOCOMO Innovations",
   "type": "drupal-profile",
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
@@ -112,12 +112,12 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Drupal\\Tests\\cloud\\": "docroot/modules/contrib/cloud/tests/src/",
       "Drupal\\Tests\\aws_cloud\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/aws_cloud/tests/src/",
+      "Drupal\\Tests\\cloud\\": "docroot/modules/contrib/cloud/tests/src/",
       "Drupal\\Tests\\k8s\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/k8s/tests/src/",
       "Drupal\\Tests\\openstack\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/openstack/tests/src/",
+      "Drupal\\Tests\\terraform\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/terraform/tests/src/",
       "Drupal\\Tests\\vmware\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/vmware/tests/src/",
-      "Drupal\\Tests\\terraform\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/terraform/tests/src/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -87,9 +87,9 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "10.0.7",
-    "drupal/core-project-message": "10.0.7",
-    "drupal/core-recommended": "10.0.7",
+    "drupal/core-composer-scaffold": "10.0.x-dev",
+    "drupal/core-project-message": "10.0.x-dev",
+    "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "6.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
     "cweagans/composer-patches": "^1",
     "drupal/core-composer-scaffold": "10.0.x-dev",
     "drupal/core-project-message": "10.0.x-dev",
-    "drupal/core-recommended": "10.0.x-dev",
+    "drupal/core-recommended": "10.0.7",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "6.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
     "cweagans/composer-patches": "^1",
     "drupal/core-composer-scaffold": "10.0.x-dev",
     "drupal/core-project-message": "10.0.x-dev",
-    "drupal/core-recommended": "10.0.7",
+    "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "6.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,8 @@
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "*",
-    "docomoinnovations/drupal-extension": "6.x-dev"
+    "docomoinnovations/drupal-extension": "6.x-dev",
+    "drupal/coder": "*"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -88,9 +88,9 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "^10.1.x-dev",
-    "drupal/core-project-message": "^10.1.x-dev",
-    "drupal/core-recommended": "^10.1.x-dev",
+    "drupal/core-composer-scaffold": "10.0.x-dev",
+    "drupal/core-project-message": "10.0.x-dev",
+    "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "dev-6.x",
@@ -108,7 +108,7 @@
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "*",
-    "docomoinnovations/drupal-extension": "6.x-dev",
+    "docomoinnovations/drupal-extension": "*",
     "drupal/coder": "*"
   },
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -87,8 +87,8 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "10.0.x-dev",
-    "drupal/core-project-message": "10.0.x-dev",
+    "drupal/core-composer-scaffold": "10.0.7",
+    "drupal/core-project-message": "10.0.7",
     "drupal/core-recommended": "10.0.7",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
     "drupal/core-recommended": "^10.1.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
-    "drupal/cloud_orchestrator": "6.x-dev",
+    "drupal/cloud_orchestrator": "dev-6.x",
     "drupal/copyright_footer": "^3",
     "drupal/ctools": "^4",
     "drupal/facade": "1.0.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
     "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
-    "drupal/cloud_orchestrator": "6.x-dev",
+    "drupal/cloud_orchestrator": "dev-6.x",
     "drupal/copyright_footer": "^3",
     "drupal/ctools": "^4",
     "drupal/facade": "1.0.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -88,9 +88,9 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "10.0.x-dev",
-    "drupal/core-project-message": "10.0.x-dev",
-    "drupal/core-recommended": "10.0.x-dev",
+    "drupal/core-composer-scaffold": "^10.0.x-dev",
+    "drupal/core-project-message": "^10.0.x-dev",
+    "drupal/core-recommended": "^10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "dev-6.x",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
     "drupal/core-recommended": "^10.1.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
-    "drupal/cloud_orchestrator": "dev-6.x",
+    "drupal/cloud_orchestrator": "6.x-dev",
     "drupal/copyright_footer": "^3",
     "drupal/ctools": "^4",
     "drupal/facade": "1.0.x-dev",
@@ -103,6 +103,10 @@
     "drupal/queue_ui": "^3",
     "drupal/simple_oauth": "^5",
     "drush/drush": "^11"
+  },
+  "require-dev": {
+    "dmore/behat-chrome-extension": "*",
+    "docomoinnovations/drupal-extension": "6.x-dev"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -88,9 +88,9 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "10.0.x-dev",
-    "drupal/core-project-message": "10.0.x-dev",
-    "drupal/core-recommended": "10.0.x-dev",
+    "drupal/core-composer-scaffold": "^10.1.x-dev",
+    "drupal/core-project-message": "^10.1.x-dev",
+    "drupal/core-recommended": "^10.1.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "dev-6.x",

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
       "Drupal\\Tests\\k8s\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/k8s/tests/src/",
       "Drupal\\Tests\\openstack\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/openstack/tests/src/",
       "Drupal\\Tests\\terraform\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/terraform/tests/src/",
-      "Drupal\\Tests\\vmware\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/vmware/tests/src/",
+      "Drupal\\Tests\\vmware\\": "docroot/modules/contrib/cloud/modules/cloud_service_providers/vmware/tests/src/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     },
     "patches": {
       "drupal/memcache": {
-        "Fixes 'variable type is integer but applied schema class is Drupal\\Core\\TypedData\\Plugin\\DataType\\BooleanData'": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
+        "Fixes an issue at https://www.drupal.org/i/3355505": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
       }
     },
     "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -55,11 +55,6 @@
         "web-root": "docroot/"
       }
     },
-    "patches": {
-      "drupal/page_load_progress": {
-        "Fixes path_alias.manager service call": "https://www.drupal.org/files/issues/2020-07-02/page_load_progress.1.x-dev.rector-3148328-4.patch"
-      }
-    },
     "installer-paths": {
       "docroot/core": [
         "type:drupal-core"
@@ -92,12 +87,12 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "^10.0.x-dev",
-    "drupal/core-project-message": "^10.0.x-dev",
-    "drupal/core-recommended": "^10.0.x-dev",
+    "drupal/core-composer-scaffold": "10.0.x-dev",
+    "drupal/core-project-message": "10.0.x-dev",
+    "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
-    "drupal/cloud_orchestrator": "dev-6.x",
+    "drupal/cloud_orchestrator": "6.x-dev",
     "drupal/copyright_footer": "^3",
     "drupal/ctools": "^4",
     "drupal/facade": "1.0.x-dev",
@@ -106,6 +101,7 @@
     "drupal/memcache": "^2",
     "drupal/module_filter": "^4",
     "drupal/queue_ui": "^3",
+    "drupal/simple_oauth": "^5",
     "drush/drush": "^11"
   },
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "allow-plugins": {
       "composer/*": true,
       "cweagans/composer-patches": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
       "drupal/*": true,
       "php-http/discovery": true
     }

--- a/composer.json
+++ b/composer.json
@@ -87,9 +87,9 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "10.0.x-dev",
-    "drupal/core-project-message": "10.0.x-dev",
-    "drupal/core-recommended": "10.0.x-dev",
+    "drupal/core-composer-scaffold": "^10.1.x-dev",
+    "drupal/core-project-message": "^10.1.x-dev",
+    "drupal/core-recommended": "^10.1.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "dev-6.x",

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,11 @@
         "web-root": "docroot/"
       }
     },
+    "patches": {
+      "drupal/memcache": {
+        "Fixes 'variable type is integer but applied schema class is Drupal\Core\TypedData\Plugin\DataType\BooleanData'": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
+      }
+    },
     "installer-paths": {
       "docroot/core": [
         "type:drupal-core"

--- a/composer.json
+++ b/composer.json
@@ -88,9 +88,9 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "^10.1.x-dev",
-    "drupal/core-project-message": "^10.1.x-dev",
-    "drupal/core-recommended": "^10.1.x-dev",
+    "drupal/core-composer-scaffold": "10.0.x-dev",
+    "drupal/core-project-message": "10.0.x-dev",
+    "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
     "drupal/cloud_orchestrator": "dev-6.x",
@@ -101,6 +101,7 @@
     "drupal/login_destination": "^2.0@beta",
     "drupal/memcache": "^2",
     "drupal/module_filter": "^4",
+    "drupal/openid_connect": "3.x-dev",
     "drupal/queue_ui": "^3",
     "drupal/simple_oauth": "^5",
     "drush/drush": "^11"

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     },
     "patches": {
       "drupal/memcache": {
-        "Fixes 'variable type is integer but applied schema class is Drupal\Core\TypedData\Plugin\DataType\BooleanData'": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
+        "Fixes 'variable type is integer but applied schema class is Drupal\\Core\\\TypedData\\\Plugin\\\DataType\\\BooleanData'": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
       }
     },
     "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -87,12 +87,12 @@
   "require": {
     "composer/installers": "^1",
     "cweagans/composer-patches": "^1",
-    "drupal/core-composer-scaffold": "^10.0.x-dev",
-    "drupal/core-project-message": "^10.0.x-dev",
-    "drupal/core-recommended": "^10.0.x-dev",
+    "drupal/core-composer-scaffold": "10.0.x-dev",
+    "drupal/core-project-message": "10.0.x-dev",
+    "drupal/core-recommended": "10.0.x-dev",
     "drupal/admin_toolbar": "^3",
     "drupal/cloud": "6.x-dev",
-    "drupal/cloud_orchestrator": "dev-6.x",
+    "drupal/cloud_orchestrator": "6.x-dev",
     "drupal/copyright_footer": "^3",
     "drupal/ctools": "^4",
     "drupal/facade": "1.0.x-dev",
@@ -101,6 +101,7 @@
     "drupal/memcache": "^2",
     "drupal/module_filter": "^4",
     "drupal/queue_ui": "^3",
+    "drupal/simple_oauth": "^5",
     "drush/drush": "^11"
   },
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     },
     "patches": {
       "drupal/memcache": {
-        "Fixes 'variable type is integer but applied schema class is Drupal\\Core\\\TypedData\\\Plugin\\\DataType\\\BooleanData'": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
+        "Fixes 'variable type is integer but applied schema class is Drupal\\Core\\TypedData\\Plugin\\DataType\\BooleanData'": "https://git.drupalcode.org/project/memcache/-/merge_requests/14.diff"
       }
     },
     "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     "allow-plugins": {
       "composer/*": true,
       "cweagans/composer-patches": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true,
       "drupal/*": true,
       "php-http/discovery": true
     }


### PR DESCRIPTION
@baldwinlouie 

I updated `composer.json`:

- Add `drupal/openid_connect` for future use of OIDC.
- Add `drupal/simple_oauth` by removing it from `drupal/cloud:6.x-dev` since it breaks the compatibility of Drupal 10.x if we keep it in `drupal/cloud:6.x-dev`.
- Add `require-dev` for the BDD testing by Behat.
- Remove `dealerdirect/phpcodesniffer-composer-installer": true,` by adding `drupal/coder` that includes it.
- Sort the `autoload-dev.psr-4` items by alphabetical order.