### PR TITLE
Removing restartPolicy parameter

### DIFF
--- a/examples/k8s/behat/deployment/cowsay-deployment.yaml
+++ b/examples/k8s/behat/deployment/cowsay-deployment.yaml
@@ -17,4 +17,3 @@ spec:
       containers:
       - name: cowsay
         image: docomoinnovations/cloud_orchestrator:cowsay
-        restartPolicy: Never


### PR DESCRIPTION
I was unable to launch this template because of the following error

`Deployment.apps "cowsay-deployment" is invalid: spec.template.spec.containers[0].restartPolicy: Forbidden: may not be set for non-init containers`

By removing that parameter, I was able to start my K8s launch template.

![Notification_Center](https://github.com/docomoinnovations/cloud_orchestrator/assets/1179859/0dcba4cd-d24b-4838-8771-a58dcddd4f19)
