### PR TITLE
Added phpstan into `allow-plugins`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
       "cweagans/composer-patches": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "drupal/*": true,
-      "php-http/discovery": true
+      "php-http/discovery": true,
+      "phpstan/extension-installer": true
     }
   },
   "extra": {


### PR DESCRIPTION
We need to add phpstan into the `allow-plugins` section, otherwise composer create-project will fail in our automated scenarios